### PR TITLE
Fix iOS header import

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Android streaming is based on [ExoPlayer](https://github.com/google/ExoPlayer)
 
 `npm install react-native-audio-streamer --save`
 
+** For react-native version < 0.40.0 install react-native-audio-streamer@0.0.9 **
+
+`npm install react-native-audio-streamer@0.0.9 --save`
+
 Then run the following command to link to iOS & Android project
 
 `react-native link react-native-audio-streamer`
@@ -75,4 +79,3 @@ _statusChanged(status) {
 
 - Audio caching
 - Buffering ratio
-

--- a/ios/RNAudioStreamer/RNAudioStreamer.h
+++ b/ios/RNAudioStreamer/RNAudioStreamer.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 @interface RNAudioStreamer : NSObject<RCTBridgeModule>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-audio-streamer",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "repository": {
     "type": "git",
     "url": "git@github.com:indiecastfm/react-native-audio-streamer.git"
@@ -21,7 +21,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react-native": ">=0.31.0"
+    "react-native": ">=0.40.0"
   },
   "main": "index.js",
   "jest": {


### PR DESCRIPTION
Since react native version 0.40.0, iOS import headers change to <React/HeaderName.h>.
More info: https://github.com/facebook/react-native/releases/tag/v0.40.0