### PR TITLE
Removed RNAudioStreamerPackage.java `createJSModules` Override

### DIFF
--- a/android/src/main/java/fm/indiecast/rnaudiostreamer/RNAudioStreamerPackage.java
+++ b/android/src/main/java/fm/indiecast/rnaudiostreamer/RNAudioStreamerPackage.java
@@ -22,7 +22,6 @@ public class RNAudioStreamerPackage implements ReactPackage {
         return modules;
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
- Removed the RNAudioStreamerPackage.java `createJSModules` override as the method can no longer be overridden. Only removed the override incase the method is used elsewhere

- Fixes the error: 

```
node_modules/react-native-device-info/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceInfo.java:26: error: method does not override or implement a method from a supertype
  @Override
  ^
```
- Tested on React Native Version `0.50.4`
- Related https://github.com/facebook/react-native/issues/15232